### PR TITLE
mention Replicate in meta, title, etc

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -2,10 +2,10 @@ import { Analytics } from "@vercel/analytics/react";
 import "../styles/globals.css";
 
 export const metdata = {
-  title: "Llama Chat",
+  title: "Llama Chat - Powered by Replicate",
   openGraph: {
-    title: "Llama Chat",
-    description: "Chat with Llama 2",
+    title: "Llama Chat - Powered by Replicate",
+    description: "I can explain concepts, write poems and code, solve logic puzzles, or even name your pets.",
   },
 };
 
@@ -13,7 +13,7 @@ export default function RootLayout({ children }) {
   return (
     <html>
       <head>
-        <title>Chat with Llama 2</title>
+        <title>Llama Chat - Powered by Replicate</title>
         <link
           rel="icon"
           href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦙</text></svg>"

--- a/app/page.js
+++ b/app/page.js
@@ -255,7 +255,7 @@ export default function HomePage() {
   return (
     <>
       <div className="bg-slate-100 border-b-2 text-center p-3">
-        Powered by Replicate. <CTA shortenedModelName={model.shortened} />
+        This open-source demo is powered by Replicate. <CTA shortenedModelName={model.shortened} />
       </div>
       <nav className="grid grid-cols-2 pt-3 pl-6 pr-3 sm:grid-cols-3 sm:pl-0">
         <div className="hidden sm:inline-block"></div>


### PR DESCRIPTION
This little adds Replicate to the page title and stuff, so it will show up more prevalently on search results, which currently look like this:

![Screenshot 2024-04-15 at 11 28 50@2x](https://github.com/replicate/llama-chat/assets/2289/4a67acd9-1b0d-4c24-89f0-6b128ca197be)
