### PR TITLE
place avatars outside speech bubbles

### DIFF
--- a/app/components/EmptyState.js
+++ b/app/components/EmptyState.js
@@ -1,10 +1,10 @@
 export default function EmptyState({ setOpen, setPrompt }) {
   return (
-    <div className="flex gap-x-4 rounded-md bg-gray-50 py-5 px-5 mb-12">
-      <span className="text-xl sm:text-2xl" title="AI">
+    <div className="flex gap-x-4 mb-8">
+      <span className="text-xl sm:text-2xl pt-4" title="AI">
         🦙
       </span>
-      <div className="flex flex-col text-sm sm:text-base flex-1 gap-y-4 mt-1">
+      <div className="flex flex-col text-sm sm:text-base flex-1 gap-y-4 mt-1 rounded-lg bg-gray-100 py-5 px-5">
         <p>I&apos;m an open-source chatbot.</p>
         <p>
           I can{" "}

--- a/app/components/Message.js
+++ b/app/components/Message.js
@@ -1,5 +1,5 @@
 const Message = ({ message, isUser }) => {
-  let containerClass = "bg-gray-50";
+  let containerClass = "bg-gray-100";
   if (isUser) {
     containerClass = "";
   }
@@ -14,19 +14,19 @@ const Message = ({ message, isUser }) => {
 
   return (
     <div
-      className={`flex gap-x-4 rounded-md ${containerClass} py-5 px-5 mb-12`}
+      className="flex gap-x-4 mb-8"
     >
       {isUser ? (
-        <span className="text-xl sm:text-2xl" title="user">
+        <span className="text-xl sm:text-2xl pt-4" title="user">
           🥸
         </span>
       ) : (
-        <span className="text-xl sm:text-2xl" title="AI">
+        <span className="text-xl sm:text-2xl pt-4" title="AI">
           🦙
         </span>
       )}
 
-      <div className="flex flex-col text-sm sm:text-base flex-1 gap-y-4 mt-1">
+      <div className={`${containerClass} flex flex-col text-sm sm:text-base flex-1 gap-y-4 mt-1 p-5 rounded-md`}>
         {message.split("\n").map(
           (text, index) =>
             text.length > 0 && (


### PR DESCRIPTION
This PR tightens up the margins a bit so there's not so much vertical space in the dialog, and places the user/assistant avatars outside the "speech bubbles".

## Before

![Screenshot 2024-04-18 at 17 36 07@2x](https://github.com/replicate/llama-chat/assets/2289/5c596fb4-3b3a-4d55-ad7f-71bca368fdb4)

## After

![Screenshot 2024-04-18 at 17 34 15@2x](https://github.com/replicate/llama-chat/assets/2289/5e5b0a24-cc09-4c43-8f2c-9c63bdb2b32d)
