### PR TITLE
quiet the model selector

### DIFF
--- a/app/components/Dropdown.js
+++ b/app/components/Dropdown.js
@@ -5,11 +5,11 @@ import { ChevronDownIcon, CheckIcon } from "@heroicons/react/20/solid";
 export default function Dropdown({ models, selectedModel, setModel }) {
   return (
     <Menu as="div" className="relative inline-flex text-left">
-      <div className="text-xl items-center">
-        <Menu.Button className="inline-flex items-center w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+      <div className="items-center">
+        <Menu.Button className="inline-flex items-center w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
           {selectedModel.name}
           {selectedModel.new && (
-            <span className="ml-2 inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-800 ring-1 ring-inset ring-blue-600/20">
+            <span className="ml-2 inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs text-blue-800 ring-1 ring-inset ring-blue-600/20">
               NEW
             </span>
           )}

--- a/app/page.js
+++ b/app/page.js
@@ -241,7 +241,7 @@ export default function HomePage() {
     <>
       <CallToAction />
       <nav className="sm:pt-8 pt-4 px-4 sm:px-12 flex items-center">
-        <div className="text-xl pr-3 font-semibold text-gray-500">
+        <div className="pr-3 font-semibold text-gray-500">
           Chat with
         </div>
         <div className="font-semibold text-gray-500 sm:text-center">


### PR DESCRIPTION
It looks kinda silly big right now, like a fever dream. This modest change makes it match the rest of the UI elements.

## Before

![Screenshot 2024-04-18 at 17 39 42@2x](https://github.com/replicate/llama-chat/assets/2289/c51ba4f8-d01c-4436-8103-5d224595356d)

## After

![Screenshot 2024-04-18 at 17 40 18@2x](https://github.com/replicate/llama-chat/assets/2289/66f5dfeb-87b0-469e-b7b9-847928ae2a59)

