### PR TITLE
prevent requests with no input

### DIFF
--- a/app/components/ChatForm.js
+++ b/app/components/ChatForm.js
@@ -3,6 +3,9 @@ import Metrics from "./Metrics";
 const ChatForm = ({ prompt, setPrompt, onSubmit, metrics, completion }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
+
+    if (prompt.length === 0) return;
+
     onSubmit(prompt);
     setPrompt("");
     event.target.rows = 1;


### PR DESCRIPTION
Requests were being made even if there was no input in the prompt field.

## Before
<img width="960" alt="image" src="https://github.com/replicate/llama-chat/assets/96904283/d977d5cf-753d-4e9b-9cc1-1328c3d59604">

## After

Added a simple check to ensure that a request is queued only if the input field is non-empty.